### PR TITLE
Expand description of type conversion for Instant and Date

### DIFF
--- a/articles/lit/reference/type-conversion.adoc
+++ b/articles/lit/reference/type-conversion.adoc
@@ -96,11 +96,15 @@ The conversion works in the same way as primitive types.
 
 | `java.util.Date`
 | A string that represents an epoch timestamp in milliseconds: `'1546300800000'` is converted to a `java.util.Date` instance that contains the value of the date `2019-01-01T00:00:00.000+0000`.
-| A non-number string, for example `'foo'`.
+
+  Or a string that follows either ISO-8601 or RFC-1123 format (e.g. `2018-10-21T12:16:24.000+00:00` for ISO-8601, `Sun, 21 Oct 2018 12:16:24 GMT` for RFC-1123).
+| A non-number string that does not conform neither to ISO-8601 nor to RFC-1123 format, for example `'foo'`.
 
 | `java.time.Instant`
 | A string that represents an epoch timestamp in seconds: `'1546300800'` is converted to a `java.time.Instant` instance that contains the value of `2019-01-01T00:00:00Z`.
-| A non-number string, for example `'foo'`.
+
+  Or a string that follows the `java.time.format.DateTimeFormatter#ISO_INSTANT` format `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'` (e.g. `'2011-12-03T10:15:30Z'`).
+| A non-number string that does not conform to `ISO_INSTANT` format, for example `'foo'`.
 
 | `java.time.LocalDate`
 | A string that follows the `java.time.format.DateTimeFormatter#ISO_LOCAL_DATE` format `yyyy-MM-dd` (e.g., `'2018-12-16'`, `'2019-01-01'`).


### PR DESCRIPTION
I implemented a basic todo list app following [this tutorial](https://hilla.dev/docs/react/start/basics), extended `Todo` entity with two new fields - `createdAtDate` and `createdAtInstant`, and then tried sending non-timestamp values for those fields from the front-end client. It worked just fine.

Source code can be found [here](https://github.com/kirmerzlikin/hilla-todo).


